### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,13 @@
 ---
-version: '3.4'
 services:
   weaviate:
-    command:
-    - --host
-    - 0.0.0.0
-    - --port
-    - '8080'
-    - --scheme
-    - http
-    image: semitechnologies/weaviate:1.10.0
+    image: cr.weaviate.io/semitechnologies/weaviate:1.27.0
+    restart: on-failure:0
     ports:
     - 8080:8080
-    restart: on-failure:0
+    - 50051:50051
     environment:
-      OPENAI_APIKEY: $OPENAI_APIKEY
-      QUERY_DEFAULTS_LIMIT: 25
+      QUERY_DEFAULTS_LIMIT: 20
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED: 'true'
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
       DEFAULT_VECTORIZER_MODULE: 'text2vec-openai'


### PR DESCRIPTION
Now in-line with the Weaviate website discussion of Docker recipes. Also compatible with version 1.27. The current version threw errors due to gRPC port not being open.